### PR TITLE
feat: add dependabot group support for commitlint packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
+    groups:
+      commitlint:
+        applies-to: version-updates
+        dependency-type: "development"
+        patterns:
+          - "@commitlint*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@ukhsa-collaboration/spectral-rules",
       "version": "0.3.0",
+      "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.0.0",
         "@commitlint/config-conventional": "^20.0.0",
@@ -32,6 +33,10 @@
         "tsx": "^4.20.6",
         "typescript": "^5.9.2",
         "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": "22",
+        "npm": ">=10"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "url": "git+https://github.com/ukhsa-collaboration/standards-api.git"
   },
   "homepage": "https://ukhsa-collaboration.github.io/standards-org/api-design-guidelines/",
+  "license": "MIT",
+  "engines": {
+    "npm": ">=10",
+    "node": "22"
+  },
   "keywords": [
     "UKHSA",
     "spectral",


### PR DESCRIPTION
@commitlint/cli and @commitlint/config-conventional should be updated together

- update package.json engines to allow newer npm versions